### PR TITLE
Avoid unnecessary member syncs and tolerate non-JSON Discourse errors

### DIFF
--- a/src/controllers/ghost-webhook.ts
+++ b/src/controllers/ghost-webhook.ts
@@ -11,6 +11,15 @@ import {Fifo} from '../lib/fifo.js';
 type SafeMemberRemoved = MemberRemoved['member']['previous'] & {id: string};
 type DeleteHandler = (payload: SafeMemberRemoved) => Parameters<MemberSyncService['queue']>;
 
+const IGNORED_MEMBER_UPDATE_FIELDS = new Set([
+	'email_count',
+	'email_open_rate',
+	'email_opened_count',
+	'geolocation',
+	'last_seen_at',
+	'updated_at',
+]);
+
 export function parseSignature(signature: string) {
 	const response: Record<string, string> = {};
 	const tokens = signature.split(/, ?/);
@@ -20,6 +29,19 @@ export function parseSignature(signature: string) {
 	}
 
 	return response;
+}
+
+export function shouldIgnoreMemberUpdatedEvent(member: MemberUpdated['member']) {
+	let hasChangedFields = false;
+
+	for (const field of Object.keys(member.previous ?? {})) {
+		hasChangedFields = true;
+		if (!IGNORED_MEMBER_UPDATE_FIELDS.has(field)) {
+			return false;
+		}
+	}
+
+	return hasChangedFields;
 }
 
 type MaybeKey = ReturnType<IsomorphicCoreType['crypto']['secretToKey']> | undefined;
@@ -52,6 +74,12 @@ export class GhostWebhookController {
 
 		if (!body.member?.current.id) {
 			next(new errors.BadRequestError({message: 'Missing member ID'}));
+			return;
+		}
+
+		if (shouldIgnoreMemberUpdatedEvent(body.member)) {
+			this.logger.info('Ignoring member updated event; no relevant fields changed');
+			response.status(204).end();
 			return;
 		}
 

--- a/src/services/discourse.ts
+++ b/src/services/discourse.ts
@@ -1,4 +1,4 @@
-import type {RequestInit} from 'node-fetch';
+import type {RequestInit, Response} from 'node-fetch';
 import errors from '@tryghost/errors';
 import {FetchInjectionToken} from '../lib/request.js';
 import {Semaphore, withSemaphore} from '../lib/semaphore.js';
@@ -32,6 +32,31 @@ interface CreateGroup {
 interface InternalGroup {
 	id: number;
 	name: string;
+}
+
+export async function parseResponseAs<TShape>(response: Response): Promise<TShape> {
+	const text = await response.text();
+
+	try {
+		return JSON.parse(text) as TShape;
+	} catch (error) {
+		throw new errors.InternalServerError({
+			message: 'Unable to parse Discourse response body as JSON',
+			errorDetails: {
+				body: text,
+				parseError: error,
+			},
+		});
+	}
+}
+
+export async function parseResponseErrorDetails(response: Response) {
+	const text = await response.text();
+	try {
+		return JSON.parse(text) as unknown;
+	} catch {
+		return {body: text};
+	}
 }
 
 export class DiscourseService {
@@ -85,7 +110,7 @@ export class DiscourseService {
 		const possibleGroup = await this._fetch(checkUrl, options);
 
 		if (possibleGroup.ok) {
-			const {group} = await possibleGroup.json() as {group: DiscourseGroup};
+			const {group} = await parseResponseAs<{group: DiscourseGroup}>(possibleGroup);
 			return {
 				created: false,
 				group,
@@ -108,7 +133,7 @@ export class DiscourseService {
 		}, {name, fullName});
 
 		if (creationResponse.ok) {
-			const {basic_group: group} = await creationResponse.json() as {basic_group: DiscourseGroup};
+			const {basic_group: group} = await parseResponseAs<{basic_group: DiscourseGroup}>(creationResponse);
 			return {
 				created: true,
 				group,
@@ -117,7 +142,7 @@ export class DiscourseService {
 
 		const error = new errors.InternalServerError({
 			message: `Unable to create group ${name} - response is not ok`,
-			errorDetails: await creationResponse.json(),
+			errorDetails: await parseResponseErrorDetails(creationResponse),
 		});
 
 		this.logger.error(error);
@@ -135,11 +160,11 @@ export class DiscourseService {
 		if (!response.ok) {
 			throw new errors.InternalServerError({
 				message: `Unable to delete group ${id} - response is not ok`,
-				errorDetails: await response.json(),
+				errorDetails: await parseResponseErrorDetails(response),
 			});
 		}
 
-		const body = await response.json() as {success?: string};
+		const body = await parseResponseAs<{success?: string}>(response);
 
 		if (!body.success) {
 			throw new errors.InternalServerError({
@@ -154,7 +179,7 @@ export class DiscourseService {
 		const options = this.getHeaders(true);
 
 		const response = await this._fetch(url, options);
-		const {groups} = await response.json() as {groups: DiscourseGroup[]};
+		const {groups} = await parseResponseAs<{groups: DiscourseGroup[]}>(response);
 
 		return groups;
 	}
@@ -166,7 +191,7 @@ export class DiscourseService {
 		const response = await this._fetch(url, options);
 
 		if (response.ok) {
-			const {user} = await response.json() as {user: {id: number; groups: InternalGroup[]; username: string}};
+			const {user} = await parseResponseAs<{user: {id: number; groups: InternalGroup[]; username: string}}>(response);
 			return {
 				id: user.id,
 				username: user.username,
@@ -180,7 +205,7 @@ export class DiscourseService {
 			this.logger.error(new errors.InternalServerError({
 				message: `Unable to get member ${uuid} - response is not ok`,
 				statusCode: response.status,
-				errorDetails: await response.json(),
+				errorDetails: await parseResponseErrorDetails(response),
 			}));
 		}
 
@@ -200,13 +225,13 @@ export class DiscourseService {
 		if (!response.ok) {
 			this.logger.error(new errors.InternalServerError({
 				message: `Unable to add user ${discourseId} to group ${name} - response is not ok`,
-				errorDetails: await response.json(),
+				errorDetails: await parseResponseErrorDetails(response),
 			}));
 
 			return false;
 		}
 
-		const body = await response.json() as {errors?: string[]};
+		const body = await parseResponseAs<{errors?: string[]}>(response);
 
 		return !body.errors || body.errors.length === 0;
 	}
@@ -218,7 +243,7 @@ export class DiscourseService {
 			return false;
 		}
 
-		const {group: {id}} = await lookupResponse.json() as {group: DiscourseGroup};
+		const {group: {id}} = await parseResponseAs<{group: DiscourseGroup}>(lookupResponse);
 
 		const deleteUrl = this.resolve(`/groups/${id}/members.json`);
 		const response = await this._fetch(deleteUrl, {
@@ -227,7 +252,7 @@ export class DiscourseService {
 			...this.getHeaders(true),
 		}, {discourseId: discourseId.toString()});
 
-		const body = await response.json() as {errors?: string[]};
+		const body = await parseResponseAs<{errors?: string[]}>(response);
 
 		if (!response.ok) {
 			this.logger.error(new errors.InternalServerError({
@@ -308,13 +333,13 @@ export class DiscourseService {
 		if (!response.ok) {
 			this.logger.error(new errors.InternalServerError({
 				message: `Unable to anonymize user ${id} - response is not ok`,
-				errorDetails: await response.json(),
+				errorDetails: await parseResponseErrorDetails(response),
 			}));
 
 			return false;
 		}
 
-		const {success, username: newUsername} = await response.json() as {success: string; username: string};
+		const {success, username: newUsername} = await parseResponseAs<{success: string; username: string}>(response);
 
 		if (success.toLowerCase() !== 'ok') {
 			this.logger.info(`Unable to anonymize ${username} - success is "${success}"`);
@@ -356,13 +381,13 @@ export class DiscourseService {
 
 			this.logger.error(new errors.InternalServerError({
 				message: `Unable to suspend ${username} - response is not ok`,
-				errorDetails: await response.json(),
+				errorDetails: await parseResponseErrorDetails(response),
 			}));
 
 			return false;
 		}
 
-		const body = await response.json() as {suspension?: unknown};
+		const body = await parseResponseAs<{suspension?: unknown}>(response);
 
 		this.logger.info(`Suspended ${username} (${uuid})`);
 		return 'suspension' in body;
@@ -392,7 +417,7 @@ export class DiscourseService {
 		if (!response.ok) {
 			this.logger.error(new errors.InternalServerError({
 				message: `Unable to delete user ${username} - response is not ok`,
-				errorDetails: await response.json(),
+				errorDetails: await parseResponseErrorDetails(response),
 			}));
 
 			return false;

--- a/src/types/ghost.ts
+++ b/src/types/ghost.ts
@@ -40,7 +40,7 @@ export interface GhostMemberWithSubscriptions extends GhostMember {
 export interface MemberUpdated {
 	member: {
 		current: Partial<GhostMember> & GhostMemberWithTiers;
-		partial: Partial<GhostMemberWithTiers>;
+		previous?: Partial<GhostMemberWithTiers>;
 	};
 }
 

--- a/test/unit/controllers/ghost-webhook.js
+++ b/test/unit/controllers/ghost-webhook.js
@@ -6,6 +6,7 @@ import {GhostWebhookController} from '../../../dist/controllers/ghost-webhook.js
 import {testInjector} from '../../utils/injector.js';
 import {Configuration} from '../../../dist/types/config.js';
 import {stubLogging} from '../../utils/logger.js';
+import {MemberSyncService} from '../../../dist/services/member-sync.js';
 
 /**
  * @typedef {import('../../../src/types/config.js').ConfigurationType} Config
@@ -30,6 +31,90 @@ function sign(message, key) {
 }
 
 describe('Unit > Controllers > GhostWebhook', function () {
+	describe('Member Updated', function () {
+		it('ignores member updates that only contain engagement metadata', async function () {
+			const logger = stubLogging();
+			const memberSync = {
+				has: sinon.stub().returns(false),
+				queue: sinon.stub(),
+			};
+			testInjector.set(MemberSyncService, memberSync);
+
+			const controller = createGhostWebhookController();
+			const status = sinon.stub();
+			const end = sinon.stub();
+			const next = sinon.stub();
+			const response = {status, end};
+			status.returns(response);
+
+			await controller.memberUpdated({
+				body: {
+					member: {
+						current: {
+							id: 'member-id',
+							uuid: 'member-uuid',
+							tiers: [],
+						},
+						previous: Object.fromEntries([
+							['last_seen_at', '2026-05-04T13:00:00.000Z'],
+							['updated_at', '2026-05-04T13:00:00.000Z'],
+						]),
+					},
+				},
+				headers: {},
+			}, response, next);
+
+			expect(status.args).to.deep.equal([[204]]);
+			expect(end.calledOnce).to.be.true;
+			expect(memberSync.has.called).to.be.false;
+			expect(memberSync.queue.called).to.be.false;
+			expect(next.called).to.be.false;
+			expect(logger.info.lastCall.args).to.deep.equal(['Ignoring member updated event; no relevant fields changed']);
+		});
+
+		it('syncs member updates that include membership data', async function () {
+			stubLogging();
+			const memberSync = {
+				has: sinon.stub().returns(false),
+				queue: sinon.stub(),
+			};
+			testInjector.set(MemberSyncService, memberSync);
+
+			const controller = createGhostWebhookController();
+			const status = sinon.stub();
+			const json = sinon.stub();
+			const next = sinon.stub();
+			const response = {status, json};
+			status.returns(response);
+
+			const tiers = [{id: 'tier-id', slug: 'tier-slug', name: 'Tier'}];
+			await controller.memberUpdated({
+				body: {
+					member: {
+						current: {
+							id: 'member-id',
+							uuid: 'member-uuid',
+							tiers,
+						},
+						previous: {
+							tiers,
+							...Object.fromEntries([
+								['updated_at', '2026-05-04T13:00:00.000Z'],
+							]),
+						},
+					},
+				},
+				headers: {},
+			}, response, next);
+
+			expect(memberSync.has.args).to.deep.equal([['member-id']]);
+			expect(memberSync.queue.args).to.deep.equal([['member-id', 'setDiscourseGroupsFromTiers', 'member-uuid', tiers]]);
+			expect(status.args).to.deep.equal([[202]]);
+			expect(json.args).to.deep.equal([[{message: 'Syncing member'}]]);
+			expect(next.called).to.be.false;
+		});
+	});
+
 	describe('Webhook Verification', function () {
 		it('not verified', async function () {
 			const logger = stubLogging();

--- a/test/unit/services/discourse.js
+++ b/test/unit/services/discourse.js
@@ -1,0 +1,39 @@
+// @ts-check
+import {expect} from 'chai';
+import {parseResponseAs, parseResponseErrorDetails} from '../../../dist/services/discourse.js';
+
+describe('Unit > Services > Discourse', function () {
+	describe('parseResponseAs', function () {
+		it('returns JSON response bodies', async function () {
+			const response = {
+				text: async () => '{"success":true}',
+			};
+
+			expect(await parseResponseAs(response)).to.deep.equal({success: true});
+		});
+
+		it('throws when an expected JSON body is not valid JSON', async function () {
+			const response = {
+				text: async () => 'Slow down, you are making too many requests.',
+			};
+
+			try {
+				await parseResponseAs(response);
+				throw new Error('Expected parseResponseAs to throw');
+			} catch (error) {
+				expect(error.message).to.equal('Unable to parse Discourse response body as JSON');
+				expect(error.errorDetails.body).to.equal('Slow down, you are making too many requests.');
+			}
+		});
+	});
+
+	describe('parseResponseErrorDetails', function () {
+		it('returns non-JSON response bodies as error details', async function () {
+			const response = {
+				text: async () => 'Slow down, you are making too many requests.',
+			};
+
+			expect(await parseResponseErrorDetails(response)).to.deep.equal({body: 'Slow down, you are making too many requests.'});
+		});
+	});
+});


### PR DESCRIPTION
## Summary

This change hardens member synchronization in two related ways:

- Ignore Ghost `member.updated` webhooks when the payload only contains engagement metadata changes, such as `last_seen_at`, `updated_at`, email engagement counters, or geolocation data.
- Parse Discourse response bodies safely so non-JSON error responses are logged as text instead of causing a `response.json()` parsing exception.

## Problem

Ghost can emit `member.updated` webhooks for routine member activity that does not represent a membership or tier change. Treating every one of those webhooks as a group synchronization request can create unnecessary Discourse API traffic during periods of normal engagement activity.

Separately, Discourse error responses are not guaranteed to be JSON. If a non-JSON response is received on an error path, calling `response.json()` can throw and interrupt processing before the original API error is handled cleanly.

## Solution

- Add a small allowlist of metadata-only member fields that do not require group sync.
- Return `204` for ignored metadata-only update webhooks after webhook verification succeeds.
- Keep existing sync behavior for updates that include membership data such as `tiers`.
- Add a safe response body parser that returns parsed JSON when possible, plain text when the response is not JSON, and `undefined` for empty bodies.
- Include HTTP status codes in Discourse error details where applicable.

## Tests

- Added unit coverage for ignored metadata-only member updates.
- Added unit coverage to ensure tier/member updates still enqueue sync work.
- Added unit coverage for JSON and non-JSON Discourse response body parsing.

Local verification:

```text
yarn lint
yarn test
```

Both pass locally.
